### PR TITLE
add reference to bigip_env

### DIFF
--- a/docs/class1/module2/lab3.rst
+++ b/docs/class1/module2/lab3.rst
@@ -53,6 +53,11 @@ Use the ``-e``, or ``--extra-vars`` argument of ``ansible-playbook``
 
    - Select ``Local Traffic -> Pools -> Pool Members -> app1_pl``
 
+.. NOTE::
+   This playbook relies on environment variables stored in the ``inventory/group_vars/bigips`` file.  This is where the ``bigip_env`` reference comes in.  Feel free to look at the file in question to get more information on the environment variables.
+   ::
+
+
 **Create pool member enable playbook**
 
 #. Create a playbook ``pmena.yaml``.


### PR DESCRIPTION
This is a departure from the playbooks used in previous examples with the environment that leverages the vars stored in a file that is not shown in the manual